### PR TITLE
/api/v1/{bouncer,test-helpers}: no duplicates

### DIFF
--- a/oonib/bouncer/handlers.py
+++ b/oonib/bouncer/handlers.py
@@ -204,7 +204,7 @@ class Bouncer(object):
                 r = self.format_alternate_address(alt)
                 if r:
                     results.append(r)
-        return results
+        return self.remove_duplicates_list(results)
 
     def formatTestHelpersWithoutPolicy(self):
         ''' Formats the test helpers without policy for the new
@@ -230,7 +230,7 @@ class Bouncer(object):
                         r = self.format_alternate_address(e)
                         if r:
                             results[k].append(r)
-        return results
+        return self.remove_duplicate_dict_values(results)
 
     @staticmethod
     def format_alternate_address(entry):
@@ -244,6 +244,24 @@ class Bouncer(object):
         if not res['front']:
             del res['front']  # make sure we do not emit a None optional field
         return res
+
+    @staticmethod
+    def remove_duplicates_list(alist):
+        # Implementation note: dictionaries are non-hashable in python
+        # so we remove duplicates using a slow approach
+        #
+        # See https://stackoverflow.com/a/7961390/4354461
+        blist = []
+        for elem in alist:
+            if elem in blist:
+                continue
+            blist.append(elem)
+        return blist
+
+    def remove_duplicate_dict_values(self, adict):
+        for key in adict.keys():
+            adict[key] = self.remove_duplicates_list(adict[key])
+        return adict
 
 
 class APIv1Collectors(OONIBHandler):

--- a/oonib/tests/test_bouncer.py
+++ b/oonib/tests/test_bouncer.py
@@ -87,6 +87,18 @@ collector:
       - {address: 'https://a.web-connectivity.th.ooni.io:4442', type: https}
       - {address: 'https://d2vt18apel48hw.cloudfront.net', front: a0.awsstatic.com,
         type: cloudfront}
+  httpo://ihiderha53f36l00.onion:
+    collector-alternate:
+    - {address: 'https://a.collector.ooni.io:4441', type: https}
+    - {address: 'https://das0y2z2ribx3.cloudfront.net', front: a0.awsstatic.com, type: cloudfront}
+    test-helper: {dns: '213.138.109.232:57004', http-return-json-headers: 'http://38.107.216.10:80',
+      ssl: 'https://213.138.109.232', tcp-echo: 213.138.109.232, traceroute: 213.138.109.232,
+      web-connectivity: 'httpo://7jne2rpg5lsaqs6b.onion'}
+    test-helper-alternate:
+      web-connectivity:
+      - {address: 'https://a.web-connectivity.th.ooni.io:4442', type: https}
+      - {address: 'https://d2vt18apel48hw.cloudfront.net', front: a0.awsstatic.com,
+        type: cloudfront}
 """
 
 reports_dir = 'data/reports'
@@ -603,6 +615,9 @@ class TestProductionTests(BaseTestBouncer):
             "address": "https://das0y2z2ribx3.cloudfront.net",
             "front": "a0.awsstatic.com",
             "type": "cloudfront"
+        }, {
+            "address": "httpo://ihiderha53f36l00.onion",
+            "type": "onion",
         }])
 
     @defer.inlineCallbacks


### PR DESCRIPTION
Closes #120

Lists are usually small (~3-5 elements), therefore I didn't felt
entitled to do any kind of smart filtering.

It would have been possible to fix duplications at a more fundamental
level, e.g., when loading. I did choose the path of not messing around
with existing code. Rather, I did just implement de-duplication when
we needed it. I am not 100% familiar with this codebase and didn't want
to perform more radical changes with possible side effects.

Because this product is approaching EOL and we should make sure we
make ooni/collector production-ready, I decided to just implement the
minimal set of changes to close the existing issue.